### PR TITLE
using oauth with aws cognito

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import functools
 import logging
 
@@ -64,7 +65,7 @@ class OAuthLogin(Home):
                 client_id=provider['client_id'],
                 redirect_uri=return_url,
                 scope=provider['scope'],
-                state=json.dumps(state),
+                state=base64.b64encode(json.dumps(state).encode()).decode()
             )
             provider['auth_link'] = "%s?%s" % (provider['auth_endpoint'], werkzeug.urls.url_encode(params))
         return providers

--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -121,7 +121,7 @@ class OAuthController(http.Controller):
     @http.route('/auth_oauth/signin', type='http', auth='none')
     @fragment_to_query_string
     def signin(self, **kw):
-        state = json.loads(kw['state'])
+        state = json.loads(base64.b64decode(kw['state']).decode())
         dbname = state['d']
         if not http.db_filter([dbname]):
             return BadRequest()

--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import json
 
 import requests
@@ -25,7 +26,7 @@ class ResUsers(models.Model):
 
     @api.model
     def _auth_oauth_rpc(self, endpoint, access_token):
-        return requests.get(endpoint, params={'access_token': access_token}).json()
+        return requests.get(endpoint, params={'access_token': access_token}, headers={'Authorization': 'Bearer %s' % access_token}).json()
 
     @api.model
     def _auth_oauth_validate(self, provider, access_token):
@@ -76,7 +77,7 @@ class ResUsers(models.Model):
         except AccessDenied as access_denied_exception:
             if self.env.context.get('no_user_creation'):
                 return None
-            state = json.loads(params['state'])
+            state = json.loads(base64.b64decode(params['state']).decode())
             token = state.get('t')
             values = self._generate_signup_values(provider, validation, params)
             try:
@@ -99,6 +100,9 @@ class ResUsers(models.Model):
             # Workaround: facebook does not send 'user_id' in Open Graph Api
             if validation.get('id'):
                 validation['user_id'] = validation['id']
+            # Workaround: cognito does not send 'user_id'
+            elif validation.get('sub'):
+                validation['user_id'] = validation['sub']
             else:
                 raise AccessDenied()
 

--- a/doc/cla/individual/jcardus.md
+++ b/doc/cla/individual/jcardus.md
@@ -1,0 +1,11 @@
+Portugal, 2021-10-4
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Joaquim Cardeira joaquim.cardeira@gmail.com https://github.com/jcardus

--- a/doc/cla/individual/jcardus.md
+++ b/doc/cla/individual/jcardus.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Joaquim Cardeira joaquim.cardeira@gmail.com https://github.com/jcardus
+Joaquim Cardeira asklocation.net@gmail.com https://github.com/jcardus


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
oauth doesn't work with aws cognito

Desired behavior after PR is merged:
oauth works with aws cognito

related issue:
https://github.com/odoo/odoo/issues/77575

serialized state json in base64 because cognito doesn't allow json
added authentication header in validation request  because that's how [cognito needs it](https://docs.aws.amazon.com/cognito/latest/developerguide/userinfo-endpoint.html)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
